### PR TITLE
[FEAT] 사용자 api 추가 및 엔티티 수정

### DIFF
--- a/src/main/java/com/gdg/backend/common/response/status/ErrorCode.java
+++ b/src/main/java/com/gdg/backend/common/response/status/ErrorCode.java
@@ -28,6 +28,9 @@ public enum ErrorCode implements BaseErrorCode {
 
     UNSIGNED(HttpStatus.BAD_REQUEST, "POST4001", "로그인 되어 있지 않습니다."),
 
+    INVALID_CODE(HttpStatus.BAD_REQUEST, "CLASS4000", "유효하지 않은 코드입니다."),
+    CLASS_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "CLASS4001", "이미 존재하는 강의실명입니다."),
+
     ;
 
 

--- a/src/main/java/com/gdg/backend/common/util/RandomCodeGenerator.java
+++ b/src/main/java/com/gdg/backend/common/util/RandomCodeGenerator.java
@@ -1,0 +1,18 @@
+package com.gdg.backend.common.util;
+
+import java.security.SecureRandom;
+
+public class RandomCodeGenerator {
+    private static final String CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public static String getRandomCode(int length) {
+        StringBuilder code = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            int index = RANDOM.nextInt(CHARACTERS.length());
+            code.append(CHARACTERS.charAt(index));
+        }
+        return code.toString();
+    }
+}
+

--- a/src/main/java/com/gdg/backend/config/WebConfig.java
+++ b/src/main/java/com/gdg/backend/config/WebConfig.java
@@ -1,11 +1,24 @@
 package com.gdg.backend.config;
 
+import com.gdg.backend.common.resolver.AuthUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import java.util.List;
+
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/com/gdg/backend/domain/classroom/controller/ClassroomController.java
+++ b/src/main/java/com/gdg/backend/domain/classroom/controller/ClassroomController.java
@@ -1,0 +1,35 @@
+package com.gdg.backend.domain.classroom.controller;
+
+import com.gdg.backend.common.annotation.AuthUser;
+import com.gdg.backend.common.response.ApiResponse;
+import com.gdg.backend.domain.classroom.entity.Classroom;
+import com.gdg.backend.domain.classroom.service.ClassroomService;
+import com.gdg.backend.domain.member.entity.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Tag(name = "강의실 관련 API", description = "강의실 관련 API입니다")
+public class ClassroomController {
+
+    private final ClassroomService classroomService;
+
+    //TODO 일단 제일 쉬운 방법으로
+    @PostMapping("/classroom/add")
+    @Operation(summary = "강의실 추가")
+    public ApiResponse<String> addClassroom(@RequestParam String name, @AuthUser Member member) {
+        return ApiResponse.onSuccess(classroomService.createClassroom(name, member));
+    }
+
+    //TODO 일단 제일 쉬운 방법으로
+    @PostMapping("/classroom/enter")
+    @Operation(summary = "강의실 입장")
+    public ApiResponse<String> enterClassroom(@RequestParam String code, @AuthUser Member member) {
+        return ApiResponse.onSuccess(classroomService.enterClassroom(code, member));
+    }
+
+}

--- a/src/main/java/com/gdg/backend/domain/classroom/entity/Classroom.java
+++ b/src/main/java/com/gdg/backend/domain/classroom/entity/Classroom.java
@@ -1,15 +1,23 @@
 package com.gdg.backend.domain.classroom.entity;
 
+import com.gdg.backend.common.exception.handler.GeneralHandler;
+import com.gdg.backend.common.response.status.ErrorCode;
 import com.gdg.backend.domain.course.entity.Course;
 import com.gdg.backend.domain.invitation.entity.Invitation;
+import com.gdg.backend.domain.member.entity.Member;
+import com.gdg.backend.domain.member.entity.Teacher;
 import com.gdg.backend.domain.notice.entity.Notice;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 
 @Entity
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Classroom {
 
     @Id
@@ -17,6 +25,11 @@ public class Classroom {
     private Long id;
 
     private String name; // 강의실 이름
+
+    private String invitationCode;
+
+    @OneToOne
+    private Teacher teacher;
 
     @OneToMany(mappedBy = "classroom")
     private List<Course> courses;
@@ -26,4 +39,15 @@ public class Classroom {
 
     @OneToMany(mappedBy = "classroom")
     private List<Invitation> invitations;
+
+    public Classroom(String name, String randomCode, Member member) {
+        this.name = name;
+        this.invitationCode = randomCode;
+
+        if(member instanceof Teacher){
+            this.teacher = (Teacher) member;
+        } else {
+            throw new GeneralHandler(ErrorCode._FORBIDDEN);
+        }
+    }
 }

--- a/src/main/java/com/gdg/backend/domain/classroom/entity/Classroom.java
+++ b/src/main/java/com/gdg/backend/domain/classroom/entity/Classroom.java
@@ -28,7 +28,7 @@ public class Classroom {
 
     private String invitationCode;
 
-    @OneToOne
+    @ManyToOne
     private Teacher teacher;
 
     @OneToMany(mappedBy = "classroom")

--- a/src/main/java/com/gdg/backend/domain/classroom/repository/ClassroomRepository.java
+++ b/src/main/java/com/gdg/backend/domain/classroom/repository/ClassroomRepository.java
@@ -1,0 +1,12 @@
+package com.gdg.backend.domain.classroom.repository;
+
+import com.gdg.backend.domain.classroom.entity.Classroom;
+import com.gdg.backend.domain.member.entity.Teacher;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
+    Optional<Classroom> findByInvitationCode(String invitationCode);
+    Boolean existsByTeacherAndName(Teacher teacher, String name);
+}

--- a/src/main/java/com/gdg/backend/domain/classroom/repository/ClassroomRepository.java
+++ b/src/main/java/com/gdg/backend/domain/classroom/repository/ClassroomRepository.java
@@ -4,9 +4,11 @@ import com.gdg.backend.domain.classroom.entity.Classroom;
 import com.gdg.backend.domain.member.entity.Teacher;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ClassroomRepository extends JpaRepository<Classroom, Long> {
     Optional<Classroom> findByInvitationCode(String invitationCode);
     Boolean existsByTeacherAndName(Teacher teacher, String name);
+    List<Classroom> findAllByTeacher(Teacher teacher);
 }

--- a/src/main/java/com/gdg/backend/domain/classroom/service/ClassroomService.java
+++ b/src/main/java/com/gdg/backend/domain/classroom/service/ClassroomService.java
@@ -1,0 +1,11 @@
+package com.gdg.backend.domain.classroom.service;
+
+import com.gdg.backend.domain.classroom.entity.Classroom;
+import com.gdg.backend.domain.member.entity.Member;
+
+public interface ClassroomService {
+
+    String createClassroom(String name, Member member);
+
+    String enterClassroom(String code, Member member);
+}

--- a/src/main/java/com/gdg/backend/domain/classroom/service/ClassroomServiceImpl.java
+++ b/src/main/java/com/gdg/backend/domain/classroom/service/ClassroomServiceImpl.java
@@ -1,0 +1,58 @@
+package com.gdg.backend.domain.classroom.service;
+
+import com.gdg.backend.common.exception.handler.GeneralHandler;
+import com.gdg.backend.common.response.status.ErrorCode;
+import com.gdg.backend.domain.classroom.entity.Classroom;
+import com.gdg.backend.domain.classroom.repository.ClassroomRepository;
+import com.gdg.backend.domain.invitation.entity.Invitation;
+import com.gdg.backend.domain.invitation.repository.InvitationRepository;
+import com.gdg.backend.domain.member.entity.Member;
+import com.gdg.backend.domain.member.entity.Student;
+import com.gdg.backend.domain.member.entity.Teacher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.gdg.backend.common.util.RandomCodeGenerator.getRandomCode;
+
+@Service
+@RequiredArgsConstructor
+public class ClassroomServiceImpl implements ClassroomService {
+
+    private final ClassroomRepository classroomRepository;
+    private final InvitationRepository invitationRepository;
+
+    @Override
+    @Transactional
+    public String createClassroom(String name, Member member) {
+
+        // 이미 존재하는 경우
+        if(classroomRepository.existsByTeacherAndName((Teacher) member, name)){
+            throw new GeneralHandler(ErrorCode.CLASS_ALREADY_EXIST);
+        }
+
+        String randomCode = getRandomCode(7);
+
+        Classroom classroom = new Classroom(name, randomCode, member);
+        classroomRepository.save(classroom);
+
+        return randomCode;
+    }
+
+    @Override
+    public String enterClassroom(String code, Member member) {
+
+        // 유효하지 않은 코드인 경우
+        Classroom classroom = classroomRepository.findByInvitationCode(code).orElseThrow(()-> new GeneralHandler(ErrorCode.INVALID_CODE));
+
+        if(member instanceof Student) {
+            Invitation invitation = new Invitation(member, classroom);
+            invitationRepository.save(invitation);
+        } else {
+            throw new GeneralHandler(ErrorCode._FORBIDDEN);
+        }
+
+        return "success";
+    }
+
+}

--- a/src/main/java/com/gdg/backend/domain/course/entity/Course.java
+++ b/src/main/java/com/gdg/backend/domain/course/entity/Course.java
@@ -22,7 +22,6 @@ public class Course {
     @JoinColumn(name = "classroom_id")
     private Classroom classroom;
 
-
     @OneToMany(mappedBy = "course")
     private List<Attendance> attendances;
 

--- a/src/main/java/com/gdg/backend/domain/invitation/entity/Invitation.java
+++ b/src/main/java/com/gdg/backend/domain/invitation/entity/Invitation.java
@@ -4,10 +4,14 @@ import com.gdg.backend.common.entity.BaseTimeEntity;
 import com.gdg.backend.domain.classroom.entity.Classroom;
 import com.gdg.backend.domain.member.entity.Member;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Invitation extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -21,4 +25,9 @@ public class Invitation extends BaseTimeEntity {
     @JoinColumn(name = "classroom_id")
     private Classroom classroom;
 
+    public Invitation(Member member, Classroom classroom) {
+        super();
+        this.member = member;
+        this.classroom = classroom;
+    }
 }

--- a/src/main/java/com/gdg/backend/domain/invitation/repository/InvitationRepository.java
+++ b/src/main/java/com/gdg/backend/domain/invitation/repository/InvitationRepository.java
@@ -1,0 +1,13 @@
+package com.gdg.backend.domain.invitation.repository;
+
+import com.gdg.backend.domain.invitation.entity.Invitation;
+import com.gdg.backend.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InvitationRepository extends JpaRepository<Invitation, Long> {
+
+    List<Invitation> findAllByMember(Member member);
+
+}

--- a/src/main/java/com/gdg/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/com/gdg/backend/domain/member/controller/MemberController.java
@@ -1,10 +1,12 @@
 package com.gdg.backend.domain.member.controller;
 
+import com.gdg.backend.common.annotation.AuthUser;
 import com.gdg.backend.common.response.ApiResponse;
 import com.gdg.backend.domain.member.dto.SignInRequestDto;
 import com.gdg.backend.domain.member.dto.SignInResponseDto;
 import com.gdg.backend.domain.member.dto.SignUpRequestDto;
 import com.gdg.backend.domain.member.dto.SignUpResponseDto;
+import com.gdg.backend.domain.member.entity.Member;
 import com.gdg.backend.domain.member.entity.Student;
 import com.gdg.backend.domain.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,10 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -35,5 +34,14 @@ public class MemberController {
     @Operation(summary = "로그인")
     public ApiResponse<SignInResponseDto> signupStudent(@RequestBody @Valid SignInRequestDto signInRequestDto) {
         return ApiResponse.onSuccess(memberService.signIn(signInRequestDto));
+    }
+
+    @GetMapping("/myprofile")
+    @Operation(summary = "대시보드 정보 가져오기")
+    public ApiResponse<Object> getDashboardInfo(@AuthUser Member member) {
+
+        System.out.println(member.getUsername());
+
+        return ApiResponse.onSuccess(memberService.getDashboardInfo(member));
     }
 }

--- a/src/main/java/com/gdg/backend/domain/member/dto/CourseInfo.java
+++ b/src/main/java/com/gdg/backend/domain/member/dto/CourseInfo.java
@@ -1,0 +1,24 @@
+package com.gdg.backend.domain.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
+
+public class CourseInfo {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class TeacherCourseInfo {
+        private String courseCode;
+        private String courseName;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class StudentCourseInfo {
+        private String teacherName;
+        private String courseName;
+    }
+}

--- a/src/main/java/com/gdg/backend/domain/member/dto/DashBoardInfoDto.java
+++ b/src/main/java/com/gdg/backend/domain/member/dto/DashBoardInfoDto.java
@@ -1,0 +1,26 @@
+package com.gdg.backend.domain.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.AllArgsConstructor;
+
+import java.util.List;
+
+public class DashBoardInfoDto {
+
+    @Getter
+    @Setter
+    @AllArgsConstructor  // 모든 필드가 있는 생성자 자동 생성
+    public static class StudentDashBoardInfoDto {
+        private String studentName;
+        private List<CourseInfo.StudentCourseInfo> studentCourseInfoList;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class TeacherDashBoardInfoDto {
+        private String teacherName;
+        private List<CourseInfo.TeacherCourseInfo> teacherCourseInfoList;
+    }
+}

--- a/src/main/java/com/gdg/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/gdg/backend/domain/member/entity/Member.java
@@ -13,7 +13,6 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @AllArgsConstructor
 public abstract class Member {
-
     @Id
     @GeneratedValue
     private Long id;
@@ -26,5 +25,4 @@ public abstract class Member {
 
     @Column(nullable = false)
     private String password;
-
 }

--- a/src/main/java/com/gdg/backend/domain/member/service/MemberService.java
+++ b/src/main/java/com/gdg/backend/domain/member/service/MemberService.java
@@ -4,8 +4,10 @@ import com.gdg.backend.domain.member.dto.SignInRequestDto;
 import com.gdg.backend.domain.member.dto.SignInResponseDto;
 import com.gdg.backend.domain.member.dto.SignUpRequestDto;
 import com.gdg.backend.domain.member.dto.SignUpResponseDto;
+import com.gdg.backend.domain.member.entity.Member;
 
 public interface MemberService {
     SignUpResponseDto register(SignUpRequestDto signUpRequestDto);
     SignInResponseDto signIn(SignInRequestDto signInRequestDto);
+    Object getDashboardInfo(Member member);
 }

--- a/src/main/java/com/gdg/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/gdg/backend/domain/member/service/MemberServiceImpl.java
@@ -4,20 +4,20 @@ import com.gdg.backend.common.exception.handler.GeneralHandler;
 import com.gdg.backend.common.jwt.CustomPasswordEncoder;
 import com.gdg.backend.common.jwt.JwtTokenProvider;
 import com.gdg.backend.common.response.status.ErrorCode;
-import com.gdg.backend.domain.member.dto.SignInRequestDto;
-import com.gdg.backend.domain.member.dto.SignInResponseDto;
-import com.gdg.backend.domain.member.dto.SignUpRequestDto;
-import com.gdg.backend.domain.member.dto.SignUpResponseDto;
+import com.gdg.backend.domain.invitation.entity.Invitation;
+import com.gdg.backend.domain.member.dto.*;
 import com.gdg.backend.domain.member.entity.Member;
 import com.gdg.backend.domain.member.entity.Student;
 import com.gdg.backend.domain.member.entity.Teacher;
+import com.gdg.backend.domain.invitation.repository.InvitationRepository;
 import com.gdg.backend.domain.member.repository.MemberRepository;
 import com.gdg.backend.domain.member.repository.StudentRepository;
 import com.gdg.backend.domain.member.repository.TeacherRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @Slf4j
@@ -27,8 +27,9 @@ public class MemberServiceImpl implements MemberService {
     private final StudentRepository studentRepository;
     private final TeacherRepository teacherRepository;
     private final MemberRepository memberRepository;
-    private final CustomPasswordEncoder passwordEncoder; // final 추가
+    private final CustomPasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
+    private final InvitationRepository invitationRepository;
 
     @Override
     public SignUpResponseDto register(SignUpRequestDto signUpRequestDto) {
@@ -100,5 +101,39 @@ public class MemberServiceImpl implements MemberService {
         log.info("[getSignInResult] SignInResultDto 객체에 값 주입");
 
         return signInResultDto;
+    }
+
+    @Override
+    public Object getDashboardInfo(Member member) {
+
+        log.info(member.getUsername());
+
+        if (member instanceof Student) {
+
+            List<Invitation> invitations = invitationRepository.findAllByMember(member);
+
+            List<CourseInfo.StudentCourseInfo> studentCourseInfos = new java.util.ArrayList<>(List.of());
+
+            invitations.forEach(invitation -> {
+                studentCourseInfos.add(new CourseInfo.StudentCourseInfo(invitation.getClassroom().getName(), invitation.getClassroom().getTeacher().getUsername()));
+            });
+
+            return new DashBoardInfoDto.StudentDashBoardInfoDto(member.getUsername(), studentCourseInfos);
+
+        } else if (member instanceof Teacher) {
+
+            List<Invitation> invitations = invitationRepository.findAllByMember(member);
+
+            List<CourseInfo.TeacherCourseInfo> teacherCourseInfos = new java.util.ArrayList<>(List.of());
+
+            invitations.forEach(invitation -> {
+                teacherCourseInfos.add(new CourseInfo.TeacherCourseInfo(invitation.getClassroom().getName(), invitation.getClassroom().getInvitationCode()));
+            });
+
+            return new DashBoardInfoDto.TeacherDashBoardInfoDto(member.getUsername(), teacherCourseInfos);
+
+        } else {
+            throw new IllegalArgumentException("Unknown member type");
+        }
     }
 }

--- a/src/main/java/com/gdg/backend/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/gdg/backend/domain/member/service/MemberServiceImpl.java
@@ -4,6 +4,8 @@ import com.gdg.backend.common.exception.handler.GeneralHandler;
 import com.gdg.backend.common.jwt.CustomPasswordEncoder;
 import com.gdg.backend.common.jwt.JwtTokenProvider;
 import com.gdg.backend.common.response.status.ErrorCode;
+import com.gdg.backend.domain.classroom.entity.Classroom;
+import com.gdg.backend.domain.classroom.repository.ClassroomRepository;
 import com.gdg.backend.domain.invitation.entity.Invitation;
 import com.gdg.backend.domain.member.dto.*;
 import com.gdg.backend.domain.member.entity.Member;
@@ -30,6 +32,7 @@ public class MemberServiceImpl implements MemberService {
     private final CustomPasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final InvitationRepository invitationRepository;
+    private final ClassroomRepository classroomRepository;
 
     @Override
     public SignUpResponseDto register(SignUpRequestDto signUpRequestDto) {
@@ -122,12 +125,12 @@ public class MemberServiceImpl implements MemberService {
 
         } else if (member instanceof Teacher) {
 
-            List<Invitation> invitations = invitationRepository.findAllByMember(member);
+            List<Classroom> classrooms = classroomRepository.findAllByTeacher((Teacher) member);
 
             List<CourseInfo.TeacherCourseInfo> teacherCourseInfos = new java.util.ArrayList<>(List.of());
 
-            invitations.forEach(invitation -> {
-                teacherCourseInfos.add(new CourseInfo.TeacherCourseInfo(invitation.getClassroom().getName(), invitation.getClassroom().getInvitationCode()));
+            classrooms.forEach(classroom -> {
+                teacherCourseInfos.add(new CourseInfo.TeacherCourseInfo(classroom.getInvitationCode(), classroom.getName()));
             });
 
             return new DashBoardInfoDto.TeacherDashBoardInfoDto(member.getUsername(), teacherCourseInfos);


### PR DESCRIPTION
<!-- PR 제목은 핵심 변경 사항을 요약해주세요 -->
<!-- ex) feat: 캐스트 생성 기능 추가 -->

## #️⃣ 연관 이슈
<!-- 연관된 이슈 번호를 적어주세요-->
> Closes #21 

## 📝 요약
<!-- 작업 내용을 요약해주세요. -->

- 사용자 대시 보드 정보 불러오기
- 강의실 생성
- 강의실 입장

## 🙏 리뷰 요청사항
<!-- 리뷰 할 때 참고했으면 하는 부분을 적어주세요. -->
<!-- 없다면 통째로 지워도 됩니다! -->

- 엔티티 수정
- Classroom 엔티티가 teacher가 1대1 대응이 되도록 변경
- Classroom 엔티티에 randomcode 필드를 추가

