### PR TITLE
[FIX] operation response 필드 설정 오류

### DIFF
--- a/src/main/java/com/gdg/backend/domain/operation/dto/OperationResponseDto.java
+++ b/src/main/java/com/gdg/backend/domain/operation/dto/OperationResponseDto.java
@@ -23,7 +23,7 @@ public class OperationResponseDto {
         response.setOperation(request.getOperation());
         response.setDocumentId(request.getDocumentId());
         response.setInsertContent(request.getInsertContent());
-        response.setDeleteLength(response.getDeleteLength());
+        response.setDeleteLength(request.getDeleteLength());
         response.setPosition(request.getPosition());
         response.setVersion(request.getBaseVersion());
         response.setUserId(request.getUserId());


### PR DESCRIPTION
<!-- PR 제목은 핵심 변경 사항을 요약해주세요 -->
<!-- ex) feat: 캐스트 생성 기능 추가 -->

## #️⃣ 연관 이슈
<!-- 연관된 이슈 번호를 적어주세요-->
> X

## 📝 요약
<!-- 작업 내용을 요약해주세요. -->

- OperationResponseDto에서 `deleteLength` 필드 잘못된 값 넣고 있던 거 수정함



## 변경사항 상세
<!-- 변경되거나 새로 만든 부분에 대한 설명 -->
### OperationResponseDto
- `of(OperationRequestDto dto)` 메소드 수정함

