### PR TITLE
[FEAT] @TrackExecutionTime 어노테이션 추가

### DIFF
--- a/src/main/java/com/gdg/backend/common/annotation/TrackExecutionTime.java
+++ b/src/main/java/com/gdg/backend/common/annotation/TrackExecutionTime.java
@@ -1,0 +1,11 @@
+package com.gdg.backend.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE}) // 메서드와 클래스에 부착 가능
+@Retention(RetentionPolicy.RUNTIME) // 런타임에도 어노테이션 남아있도록 설정
+public @interface TrackExecutionTime {
+}

--- a/src/main/java/com/gdg/backend/common/annotation/aspect/ExecutionTimeAspect.java
+++ b/src/main/java/com/gdg/backend/common/annotation/aspect/ExecutionTimeAspect.java
@@ -1,0 +1,29 @@
+package com.gdg.backend.common.annotation.aspect;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Slf4j
+@Component
+public class ExecutionTimeAspect {
+
+    @Around("@annotation(com.gdg.backend.common.annotation.TrackExecutionTime) " +
+            "|| @within(com.gdg.backend.common.annotation.TrackExecutionTime) " +
+            "|| execution(* org.springframework.data.jpa.repository.JpaRepository+.*(..))") // JPA Repository 포함
+    public Object trackExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        // 메서드 실행 전후로 실행시간 측정
+        long start = System.currentTimeMillis();
+        Object proceed = joinPoint.proceed(); // 기존 메서드 실행
+        long end = System.currentTimeMillis();
+
+        String className = joinPoint.getSignature().getDeclaringType().getSimpleName();
+        String methodName = joinPoint.getSignature().getName();
+        log.info(className + ": " + methodName + "() took " + (end - start) + "ms");
+        return proceed;
+    }
+}

--- a/src/main/java/com/gdg/backend/common/annotation/aspect/ExecutionTimeAspect.java
+++ b/src/main/java/com/gdg/backend/common/annotation/aspect/ExecutionTimeAspect.java
@@ -14,7 +14,8 @@ public class ExecutionTimeAspect {
 
     @Around("@annotation(com.gdg.backend.common.annotation.TrackExecutionTime) " +
             "|| @within(com.gdg.backend.common.annotation.TrackExecutionTime) " +
-            "|| execution(* org.springframework.data.jpa.repository.JpaRepository+.*(..))") // JPA Repository 포함
+            "|| execution(* org.springframework.data.jpa.repository.JpaRepository+.*(..))" + // JPA Repository 포함
+            "|| execution(* org.springframework.messaging.simp.SimpMessagingTemplate.convertAndSend(..))") // SimpMessagingTemplate 포함
     public Object trackExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
         // 메서드 실행 전후로 실행시간 측정
         long start = System.currentTimeMillis();

--- a/src/main/java/com/gdg/backend/domain/member/entity/Member.java
+++ b/src/main/java/com/gdg/backend/domain/member/entity/Member.java
@@ -14,7 +14,7 @@ import lombok.experimental.SuperBuilder;
 @AllArgsConstructor
 public abstract class Member {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)

--- a/src/main/java/com/gdg/backend/domain/operation/dto/OperationResponseDto.java
+++ b/src/main/java/com/gdg/backend/domain/operation/dto/OperationResponseDto.java
@@ -29,4 +29,15 @@ public class OperationResponseDto {
         response.setUserId(request.getUserId());
         return response;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(operation).append(" ");
+        if(operation.equals(OperationType.INSERT)) sb.append("'" + insertContent + "' ");
+        if(operation.equals(OperationType.DELETE)) sb.append(deleteLength + " ");
+        sb.append("pos=").append(position).append(" ")
+                .append(String.format("docId=%d, version=%d, userId=%d", documentId, version, userId));
+        return sb.toString();
+    }
 }

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -13,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -98,6 +101,11 @@ public class OperationQueueProcessor {
         //   -> 클라이언트 ACK 추적 기능 구현 되면 (2)번으로 갈아타기
 
         try {
+            // 로그 출력
+            ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+            System.out.println(now.format(formatter) + " Received: " + operation);
+
             Long docId = operation.getDocumentId();
             Long baseVersion = operation.getBaseVersion();
             Long opPosition = operation.getPosition();
@@ -129,7 +137,6 @@ public class OperationQueueProcessor {
             // - todo 메모리에 Operation랑 Document 캐싱하기
             //   - Operation은 큐 만들어서 캐싱하기 (클라이언트 ACK에 맞춰 갱신)
             //   - Document는 Map<UserID, Document> 형식 or Map<UserId, StringBuilder> 형식으로 저장?
-            long start = System.currentTimeMillis();
             operationRepository.save(Operation.builder()
                     .operation(response.getOperation())
                     .document(documentRepository.findById(docId).orElseThrow()) // todo
@@ -140,13 +147,9 @@ public class OperationQueueProcessor {
                     .member(null) // todo
                     .build()
             );
-            long end = System.currentTimeMillis();
-            System.out.println("OperationRepository: save() took " + (end - start) + "ms");
 
             // 로그 출력
-            System.out.println("Received: " + operation);
-            System.out.println("  수정된 위치: " + opPosition);
-            System.out.println("  수정된 버전: " + response.getVersion());
+            System.out.println("  수정된 Operation: " + response);
 
             // 클라이언트에 브로드캐스트
             template.convertAndSend("/sub/edit/" + docId, response);

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -10,6 +10,7 @@ import com.gdg.backend.domain.operation.entity.Operation;
 import com.gdg.backend.domain.operation.repository.OperationRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
@@ -23,6 +24,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 
 /** OperationType 큐에서 주기적으로 이벤트를 가져와 처리하는 클래스 */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class OperationQueueProcessor {
@@ -104,7 +106,7 @@ public class OperationQueueProcessor {
             // 로그 출력
             ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-            System.out.println(now.format(formatter) + " Received: " + operation);
+            log.info("{} Received: {}", now.format(formatter), operation);
 
             Long docId = operation.getDocumentId();
             Long baseVersion = operation.getBaseVersion();
@@ -149,7 +151,7 @@ public class OperationQueueProcessor {
             );
 
             // 로그 출력
-            System.out.println("  수정된 Operation: " + response);
+           log.info("  수정된 Operation: {}", response);
 
             // 클라이언트에 브로드캐스트
             template.convertAndSend("/sub/edit/" + docId, response);

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -1,5 +1,6 @@
 package com.gdg.backend.domain.operation.service;
 
+import com.gdg.backend.common.annotation.TrackExecutionTime;
 import com.gdg.backend.domain.document.entity.Document;
 import com.gdg.backend.domain.document.repository.DocumentRepository;
 import com.gdg.backend.domain.enums.OperationType;
@@ -80,6 +81,7 @@ public class OperationQueueProcessor {
         System.out.println("FILLED DOCUMENT POOL: " + documentVersions);
     }
 
+    @TrackExecutionTime
     private void processOperation(OperationRequestDto operation) {
         // todo documentID 없는 경우 예외 처리
 
@@ -127,6 +129,7 @@ public class OperationQueueProcessor {
             // - todo 메모리에 Operation랑 Document 캐싱하기
             //   - Operation은 큐 만들어서 캐싱하기 (클라이언트 ACK에 맞춰 갱신)
             //   - Document는 Map<UserID, Document> 형식 or Map<UserId, StringBuilder> 형식으로 저장?
+            long start = System.currentTimeMillis();
             operationRepository.save(Operation.builder()
                     .operation(response.getOperation())
                     .document(documentRepository.findById(docId).orElseThrow()) // todo
@@ -137,6 +140,8 @@ public class OperationQueueProcessor {
                     .member(null) // todo
                     .build()
             );
+            long end = System.currentTimeMillis();
+            System.out.println("OperationRepository: save() took " + (end - start) + "ms");
 
             // 로그 출력
             System.out.println("Received: " + operation);


### PR DESCRIPTION
<!-- PR 제목은 핵심 변경 사항을 요약해주세요 -->
<!-- ex) feat: 캐스트 생성 기능 추가 -->

## #️⃣ 연관 이슈
<!-- 연관된 이슈 번호를 적어주세요-->
> Closes #25 

## 📝 요약
<!-- 작업 내용을 요약해주세요. -->
- 어노테이션 추가 & OperationQueueProcessor에 부착
  - 더 부착하고 싶은 데 있으면 맘대로 붙이기

## 🙏 리뷰 요청사항
<!-- 리뷰 할 때 참고했으면 하는 부분을 적어주세요. -->
<!-- 없다면 통째로 지워도 됩니다! -->
- Member id에 Generation strategy가 설정 안돼있길래 설정해둠
  - 혹시 의도한 거면 얘기해주세요
- Pointcut에 JPARepository 구현체 + SimpMessagingTemplate도 추가
  - 나중에 수정하려면 `ExecutionTimeAspect` 포인트컷 마지막 두 줄 지우면 됨


## 변경사항 상세
<!-- 변경되거나 새로 만든 부분에 대한 설명 -->
### `@TrackExecutionTime` 추가
- OperationQueueProcessor와 JPARepository 구현체, SimpMessagingTemplate에 적용
### Member id generation strategy 설정
- `GenerationType.IDENTITY`로 설정함