### PR TITLE
[FEAT] 문서 상태 캐싱

### DIFF
--- a/src/main/java/com/gdg/backend/BackendApplication.java
+++ b/src/main/java/com/gdg/backend/BackendApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/gdg/backend/common/response/status/ErrorCode.java
+++ b/src/main/java/com/gdg/backend/common/response/status/ErrorCode.java
@@ -31,6 +31,8 @@ public enum ErrorCode implements BaseErrorCode {
     INVALID_CODE(HttpStatus.BAD_REQUEST, "CLASS4000", "유효하지 않은 코드입니다."),
     CLASS_ALREADY_EXIST(HttpStatus.BAD_REQUEST, "CLASS4001", "이미 존재하는 강의실명입니다."),
 
+    // 문서 관련 에러
+    DOCUMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "DOCUMENT4001", "문서를 찾을 수 없습니다."),
     ;
 
 

--- a/src/main/java/com/gdg/backend/domain/document/entity/Document.java
+++ b/src/main/java/com/gdg/backend/domain/document/entity/Document.java
@@ -28,11 +28,6 @@ public class Document extends BaseTimeEntity {
     @Transient
     private StringBuilder contentBuilder;
 
-    @PostLoad // JPA가 DB에서 로드한 후 호출
-    public void initContentBuilder() {
-        this.contentBuilder = new StringBuilder(content != null ? content : "");
-    }
-
     public StringBuilder getContentBuilder() {
         if(contentBuilder == null) initContentBuilder();
         return contentBuilder;
@@ -40,5 +35,20 @@ public class Document extends BaseTimeEntity {
 
     public void syncContentBuilder() {
         if(contentBuilder != null) content = contentBuilder.toString();
+    }
+
+    // DB에서 로드 시 content -> contentBuilder 초기화
+    @PostLoad
+    public void initContentBuilder() {
+        this.contentBuilder = new StringBuilder(content != null ? content : "");
+    }
+
+    // INSERT, UPDATE 전 contentBuilder -> content 동기화
+    @PrePersist
+    @PreUpdate 
+    public void syncContentBeforeSave() {
+        if (contentBuilder != null) {
+            content = contentBuilder.toString();
+        }
     }
 }

--- a/src/main/java/com/gdg/backend/domain/document/entity/Document.java
+++ b/src/main/java/com/gdg/backend/domain/document/entity/Document.java
@@ -1,10 +1,7 @@
 package com.gdg.backend.domain.document.entity;
 
 import com.gdg.backend.common.entity.BaseTimeEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
@@ -23,4 +20,25 @@ public class Document extends BaseTimeEntity {
 
     @Setter
     private Long version;
+
+    /**
+     * content 수정용 StringBuilder (content 직접 수정은 String이므로 오래 걸림)
+     * !! 주의: DB 저장 전에 syncContentBuilder() 등으로 contentBuilder -> content 동기화 필요 !!
+     * */
+    @Transient
+    private StringBuilder contentBuilder;
+
+    @PostLoad // JPA가 DB에서 로드한 후 호출
+    public void initContentBuilder() {
+        this.contentBuilder = new StringBuilder(content != null ? content : "");
+    }
+
+    public StringBuilder getContentBuilder() {
+        if(contentBuilder == null) initContentBuilder();
+        return contentBuilder;
+    }
+
+    public void syncContentBuilder() {
+        if(contentBuilder != null) content = contentBuilder.toString();
+    }
 }

--- a/src/main/java/com/gdg/backend/domain/enums/OperationType.java
+++ b/src/main/java/com/gdg/backend/domain/enums/OperationType.java
@@ -4,5 +4,6 @@ public enum OperationType {
     INSERT,
     DELETE,
     UPDATE,
-    CURSOR
+    CURSOR,
+    SYNC
 }

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -112,11 +112,21 @@ public class OperationQueueProcessor {
         Long baseVersion = operation.getBaseVersion();
         Long opPosition = operation.getPosition();
 
-        // documentID 없는 경우 예외처리 (documentCache 확인 -> DB 확인)
-        // - 캐시엔 없지만 DB에 있는 경우 캐시 업데이트
+        // documentID 없는 경우 예외처리 (캐시엔 없지만 DB에 있는 경우 캐시 업데이트)
         Document doc = documentCache.computeIfAbsent(docId, id -> documentRepository.findById(docId)
                 .orElseThrow(() -> new GeneralHandler(ErrorCode.DOCUMENT_NOT_FOUND))
         );
+
+        // SYNC인 경우 따로 처리
+        // - 현재 문서 상태 브로드캐스팅
+        // - version을 높이지 않음
+        // - 추후 전략 패턴 등으로 추상화
+        if(operation.getOperation().equals(OperationType.SYNC)) {
+            System.out.println("Received: SYNC");
+            String ret = doc.getContentBuilder().toString();
+            template.convertAndSend("/sub/edit/" + docId, ret);
+            return;
+        }
 
         // operation 충돌 시 변환 처리
         // - operation의 baseVersion과 서버가 추적하는 version을 비교

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -1,5 +1,7 @@
 package com.gdg.backend.domain.operation.service;
 
+import com.gdg.backend.common.exception.handler.GeneralHandler;
+import com.gdg.backend.common.response.status.ErrorCode;
 import com.gdg.backend.domain.document.entity.Document;
 import com.gdg.backend.domain.document.repository.DocumentRepository;
 import com.gdg.backend.domain.enums.OperationType;
@@ -30,7 +32,7 @@ public class OperationQueueProcessor {
     private final ConcurrentHashMap<Long, AtomicLong> documentVersions = new ConcurrentHashMap<>();
 
     // 문서 상태 추적 (Stringbuilder vs Document?)
-    private final ConcurrentHashMap<Long, StringBuilder> documentState = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<Long, Document> documentCache = new ConcurrentHashMap<>();
 
     @PostConstruct
     public void startProcessing() {
@@ -52,11 +54,16 @@ public class OperationQueueProcessor {
         }).start();
     }
 
-    /** DB에 존재하는 Document version pool 추적 (인메모리라서 서버 껐다키면 사라지니까..) */
     @PostConstruct
-    public void fillDocumentVersionPool () {
+    public void postConstructJob() {
+        createTestDocument();
+        fillDocumentPool();
+        fillDocumentVersionPool();
+    }
+
+    /** (임시) 테스트 문서 초기화 -> 다른 PostConstruct 메소드보다 먼저 호출되어야 함 */
+    private void createTestDocument() {
         try {
-            // (임시) 테스트 문서 초기화
             final Long TEST_DOC_ID = 1L;
             Document testDoc = documentRepository.findById(TEST_DOC_ID)
                     .orElse(Document.builder()
@@ -68,10 +75,23 @@ public class OperationQueueProcessor {
             // (임시) 테스트 문서 operation 로그 초기화
             operationRepository.deleteByDocumentId(TEST_DOC_ID);
         } catch (Exception e) {
-            System.out.println("Exception while initializing OperationQueueProcessor");
+            System.out.println("Exception while creating test document");
             System.out.println(e.getMessage());
         }
+    }
 
+    /** DB에서 Document fetch해서 메모리로 가져옴 */
+//    @PostConstruct
+    public void fillDocumentPool() {
+        List<Document> documents = documentRepository.findAll();
+        for(Document doc : documents) {
+            documentCache.put(doc.getId(), doc);
+        }
+    }
+
+    /** DB에 존재하는 Document version pool 추적 (인메모리라서 서버 껐다키면 사라지니까..) */
+//    @PostConstruct
+    public void fillDocumentVersionPool () {
         List<Document> documents = documentRepository.findAll();
         documents.stream().forEach(document -> {
             if(document.getVersion() > documentVersions.getOrDefault(document.getId(), new AtomicLong(-1)).get())
@@ -80,8 +100,18 @@ public class OperationQueueProcessor {
         System.out.println("FILLED DOCUMENT POOL: " + documentVersions);
     }
 
-    private void processOperation(OperationRequestDto operation) {
-        // todo documentID 없는 경우 예외 처리
+    public void processOperation(OperationRequestDto operation) {
+        Long docId = operation.getDocumentId();
+        Long baseVersion = operation.getBaseVersion();
+        Long opPosition = operation.getPosition();
+
+        // documentID 없는 경우 예외처리 (documentState 확인 -> DB 확인)
+        Document doc = documentCache.computeIfAbsent(docId, id -> {
+            Document newDoc = documentRepository.findById(docId)
+                    .orElseThrow(() -> new GeneralHandler(ErrorCode.DOCUMENT_NOT_FOUND));
+            documentCache.put(id, newDoc); // 새로 만든 문서 캐싱
+            return newDoc;
+        });
 
         // operation 충돌 시 변환 처리
         // - operation의 baseVersion과 서버가 추적하는 version을 비교
@@ -94,11 +124,7 @@ public class OperationQueueProcessor {
         //   - 클라가 전부 version 11까지는 받았다 -> version 10 이상은 메모리에서 해제
         //   - queue로 구현해서, 클라이언트 ACK 받을 시 queue에서 옛날 event pop / 새로운 event 받을 시 queue에 push
         //   -> 클라이언트 ACK 추적 기능 구현 되면 (2)번으로 갈아타기
-
         try {
-            Long docId = operation.getDocumentId();
-            Long baseVersion = operation.getBaseVersion();
-            Long opPosition = operation.getPosition();
             List<Operation> concurrentOperations = operationRepository.findByDocumentIdAndVersionGreaterThan(docId, baseVersion);
             for (Operation concurrentOp : concurrentOperations) {
                 if (concurrentOp.getOperation().equals(OperationType.INSERT)
@@ -119,17 +145,25 @@ public class OperationQueueProcessor {
             response.setPosition(opPosition);
             response.setVersion(documentVersions.get(operation.getDocumentId()).incrementAndGet());
 
-            // todo 서버 문서 상태에도 변경사항 가함
-
+            // 문서 상태 갱신
+            int idx = Math.toIntExact(opPosition);
+            switch(operation.getOperation()) {
+                case INSERT -> {
+                    doc.getContentBuilder().insert(idx, operation.getInsertContent());
+                }
+                case DELETE -> {
+                    doc.getContentBuilder().delete(idx, operation.getDeleteLength());
+                }
+            }
 
             // Operation DB에 저장 && Document version 업데이트
             // - 동기 처리 vs 비동기 처리
-            // - todo 메모리에 Operation랑 Document 캐싱하기
+            // - todo 메모리에 Operation 캐싱하기
             //   - Operation은 큐 만들어서 캐싱하기 (클라이언트 ACK에 맞춰 갱신)
             //   - Document는 Map<UserID, Document> 형식 or Map<UserId, StringBuilder> 형식으로 저장?
             operationRepository.save(Operation.builder()
                     .operation(response.getOperation())
-                    .document(documentRepository.findById(docId).orElseThrow()) // todo
+                    .document(doc)
                     .position(response.getPosition())
                     .insertContent(response.getInsertContent())
                     .deleteLength(response.getDeleteLength())

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -193,6 +193,8 @@ public class OperationQueueProcessor {
     @Scheduled(fixedRate = 10000) // 10초마다 실행
     @Transactional
     public void saveDirtyDocuments() {
+        // 로그 출력
+        if(!dirtyDocuments.isEmpty()) System.out.println("SAVING DIRTY DOCUMENTS (id=" + dirtyDocuments + ")");
         for (Long docId : dirtyDocuments) {
             Document doc = documentCache.get(docId);
             if (doc != null) {

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -123,8 +123,8 @@ public class OperationQueueProcessor {
         // - 추후 전략 패턴 등으로 추상화
         if(operation.getOperation().equals(OperationType.SYNC)) {
             System.out.println("Received: SYNC");
-            String ret = doc.getContentBuilder().toString();
-            template.convertAndSend("/sub/edit/" + docId, ret);
+            String docContent = doc.getContentBuilder().toString();
+            template.convertAndSend("/sub/edit/" + docId, docContent);
             return;
         }
 

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -154,6 +154,7 @@ public class OperationQueueProcessor {
                 case INSERT -> doc.getContentBuilder().insert(idx, operation.getInsertContent());
                 case DELETE -> doc.getContentBuilder().delete(idx, operation.getDeleteLength());
             }
+            dirtyDocuments.add(docId);
             doc.syncContentBuilder();
 
             // Operation DB에 저장 && Document version 업데이트

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -12,9 +12,13 @@ import com.gdg.backend.domain.operation.repository.OperationRepository;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
@@ -34,6 +38,8 @@ public class OperationQueueProcessor {
     // 문서 상태 캐싱
     // - todo 문서 많아지면 OutOfMemory 발생할 수도 있음 -> 추후에 LRU나 TTL 설정
     private final ConcurrentHashMap<Long, Document> documentCache = new ConcurrentHashMap<>();
+
+    private final Set<Long> dirtyDocuments = new HashSet<>(); // 변경된 Document 추적 (주기적으로 저장)
 
     @PostConstruct
     public void startProcessing() {
@@ -176,5 +182,25 @@ public class OperationQueueProcessor {
             System.out.println("Exception while handling operation " + operation);
             System.out.println(e.getMessage());
         }
+    }
+
+    /** 주기적으로 변경된 문서 저장 <br>
+     * - DB 쓰기는 네트워크 요청 + 디스크 I/O를 포함하므로 무거움
+     * - processOperation에서 제거해서 실행시간 줄여서 사용자 경험 증가 & 트랜잭션 부하 감소
+     * - 실시간성은 documentCache로 유지하고 저장은 백그라운드에서 주기적으로 진행
+     * */
+    @Scheduled(fixedRate = 10000) // 10초마다 실행
+    @Transactional
+    public void saveDirtyDocuments() {
+        for (Long docId : dirtyDocuments) {
+            Document doc = documentCache.get(docId);
+            if (doc != null) {
+                synchronized (doc) {
+                    doc.syncContentBuilder();
+                    documentRepository.save(doc);
+                }
+            }
+        }
+        dirtyDocuments.clear();
     }
 }

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -31,7 +31,8 @@ public class OperationQueueProcessor {
     private final SimpMessagingTemplate template;
     private final ConcurrentHashMap<Long, AtomicLong> documentVersions = new ConcurrentHashMap<>();
 
-    // 문서 상태 추적 (Stringbuilder vs Document?)
+    // 문서 상태 캐싱
+    // - todo 문서 많아지면 OutOfMemory 발생할 수도 있음 -> 추후에 LRU나 TTL 설정
     private final ConcurrentHashMap<Long, Document> documentCache = new ConcurrentHashMap<>();
 
     @PostConstruct
@@ -105,35 +106,31 @@ public class OperationQueueProcessor {
         Long baseVersion = operation.getBaseVersion();
         Long opPosition = operation.getPosition();
 
-        // documentID 없는 경우 예외처리 (documentState 확인 -> DB 확인)
-        Document doc = documentCache.computeIfAbsent(docId, id -> {
-            Document newDoc = documentRepository.findById(docId)
-                    .orElseThrow(() -> new GeneralHandler(ErrorCode.DOCUMENT_NOT_FOUND));
-            documentCache.put(id, newDoc); // 새로 만든 문서 캐싱
-            return newDoc;
-        });
+        // documentID 없는 경우 예외처리 (documentCache 확인 -> DB 확인)
+        // - 캐시엔 없지만 DB에 있는 경우 캐시 업데이트
+        Document doc = documentCache.computeIfAbsent(docId, id -> documentRepository.findById(docId)
+                .orElseThrow(() -> new GeneralHandler(ErrorCode.DOCUMENT_NOT_FOUND))
+        );
 
         // operation 충돌 시 변환 처리
         // - operation의 baseVersion과 서버가 추적하는 version을 비교
-        // - 차이나는 version만큼 position을 업데이트한다 (insert: position 증가 / delete: position 감소)
+        //   - 차이나는 version만큼 position을 업데이트한다 (insert: position 증가 / delete: position 감소)
         // - 이전 version의 이벤트 추적 방법
         // - (1) DB에서 가져온다 -> 구현이 쉬우니까 일단 이걸로 감
         //   - 대신 DB 가져오는 시간이 너무 오래 걸릴 거임
         // - (2) 메모리에 킵한다 -> 얼마나 킵할지 알 수 없음 (전부 킵하면 결국 OutOfMemory 뜰거임)
-        //   - 연결된 클라들이 어느 version까지 받았는지 추적할 수 있으면 메모리 할당량 조절 가능
+        //   - 연결된 클라들이 어느 version까지 받았는지 추적하면 메모리 할당량 조절 가능
         //   - 클라가 전부 version 11까지는 받았다 -> version 10 이상은 메모리에서 해제
         //   - queue로 구현해서, 클라이언트 ACK 받을 시 queue에서 옛날 event pop / 새로운 event 받을 시 queue에 push
         //   -> 클라이언트 ACK 추적 기능 구현 되면 (2)번으로 갈아타기
         try {
             List<Operation> concurrentOperations = operationRepository.findByDocumentIdAndVersionGreaterThan(docId, baseVersion);
             for (Operation concurrentOp : concurrentOperations) {
-                if (concurrentOp.getOperation().equals(OperationType.INSERT)
-                        && concurrentOp.getPosition() < opPosition) {
+                if (concurrentOp.getOperation().equals(OperationType.INSERT) && concurrentOp.getPosition() < opPosition) {
                     // 현재 operation보다 앞에 삽입한 경우
                     if(concurrentOp.getInsertContent() == null) continue;;
                     opPosition += concurrentOp.getInsertContent().length();
-                } else if (concurrentOp.getOperation().equals(OperationType.DELETE)
-                        && concurrentOp.getPosition() < opPosition) {
+                } else if (concurrentOp.getOperation().equals(OperationType.DELETE) && concurrentOp.getPosition() < opPosition) {
                     // 현재 operation보다 앞을 삭제한 경우
                     if(concurrentOp.getDeleteLength() == null) continue;;
                     opPosition -= concurrentOp.getDeleteLength();
@@ -148,19 +145,15 @@ public class OperationQueueProcessor {
             // 문서 상태 갱신
             int idx = Math.toIntExact(opPosition);
             switch(operation.getOperation()) {
-                case INSERT -> {
-                    doc.getContentBuilder().insert(idx, operation.getInsertContent());
-                }
-                case DELETE -> {
-                    doc.getContentBuilder().delete(idx, operation.getDeleteLength());
-                }
+                case INSERT -> doc.getContentBuilder().insert(idx, operation.getInsertContent());
+                case DELETE -> doc.getContentBuilder().delete(idx, operation.getDeleteLength());
             }
+            doc.syncContentBuilder();
 
             // Operation DB에 저장 && Document version 업데이트
             // - 동기 처리 vs 비동기 처리
             // - todo 메모리에 Operation 캐싱하기
-            //   - Operation은 큐 만들어서 캐싱하기 (클라이언트 ACK에 맞춰 갱신)
-            //   - Document는 Map<UserID, Document> 형식 or Map<UserId, StringBuilder> 형식으로 저장?
+            //   - Operation 큐 만들어서 캐싱하기 (클라이언트 ACK에 맞춰 갱신)
             operationRepository.save(Operation.builder()
                     .operation(response.getOperation())
                     .document(doc)


### PR DESCRIPTION
<!-- PR 제목은 핵심 변경 사항을 요약해주세요 -->
<!-- ex) feat: 캐스트 생성 기능 추가 -->

## #️⃣ 연관 이슈
<!-- 연관된 이슈 번호를 적어주세요-->
> Closes #15, #17

## 📝 요약
<!-- 작업 내용을 요약해주세요. -->
- 메모리에 문서 상태 `Map<ID, Document>` 형태로 저장
- 문자열 작업 효율화를 위해 Document 엔티티에 `StringBuilder contentBuilder` 필드 추가
- 주기적으로 DB에 문서 상태 저장

\+ SYNC 수신 시 문서 상태 브로드캐스트 기능 추가
  - 원래 다른 브랜치에 만들려 했는데 리뷰 전에 빨리 구현하는 게 낫겠다 싶어서 여기다가 같이 넣음

## 🏴 변경사항 상세
<!-- 변경되거나 새로 만든 부분에 대한 설명 -->
### 문서 상태 메모리에 저장
- `@PostConstruct` 후 `fillDocumentPool()`에서 DB에 있는 문서 읽어서 `documentCache`에 저장
- `documentId`가 없는 경우 DB에서 Document 가져와서 캐시 업데이트
- 작업 내용 설명
### `Document` 엔티티에 `StringBuilder contentBuilder` 필드 추가
- `content`는 String이라서 문자열 수정할 때마다 새로운 객체 생성됨 -> 비효율적
- StringBuilder로 문자열 작업하되, DB 저장 전에 매번 `syncContentBuilder()`로 content 동기화
  - Document 안에 안전장치로 메소드 이것저것 만들어두긴 했는데, 그래도 명시적으로 동기화해서 나쁠 건 없을 듯
### `@Scheduled`로 백그라운드에서 DB 문서 상태 저장
- `processOperation()`에서 문서 변경 시 `dirtyDocuments`에 추가됨
- 10초마다 `dirtyDocuments`에 쌓인 문서들 DB에 저장
### SYNC 수신 시 현재 문서 상태 브로드캐스트
- `processOperation()` 메소드가 점점 뚱뚱해지고 있음
- 언젠가 리팩토링할 듯
