### PR TITLE
[FIX] Document content 동기화 문제 해결

### DIFF
--- a/src/main/java/com/gdg/backend/domain/document/entity/Document.java
+++ b/src/main/java/com/gdg/backend/domain/document/entity/Document.java
@@ -39,25 +39,14 @@ public class Document extends BaseTimeEntity {
 
     // DB에서 로드 시 content -> contentBuilder 초기화
     @PostLoad
-    @PostPersist
     public void initContentBuilder() {
-        this.contentBuilder = new StringBuilder(content != null ? content : "");
-        System.out.println("DOCUMENT " + id + " CONTENTBUILDER INITIATED (value=" + contentBuilder + ")");
-    }
-
-    // INSERT, UPDATE 전 contentBuilder -> content 동기화
-    @PrePersist
-    @PreUpdate 
-    public void syncContentBeforeSave() {
-        System.out.println("SyncContentBeforeSave(): contentBuilder=" + contentBuilder + " content=" + content);
-        if (contentBuilder != null) {
-            content = contentBuilder.toString();
-            System.out.println("SyncContentBeforeSave(): contentBuilder=" + contentBuilder.toString() + " content=" + content);
-        }
+        if(content == null) content = "";
+        this.contentBuilder = new StringBuilder(content);
+        System.out.println("DOCUMENT " + id + " ContentBuilder INITIATED (value=" + contentBuilder + ")");
     }
 
     @Override
     public String toString() {
-        return String.format("DOCUMENT(id=%d, version=%d, contentBuilder=%s", id, version, contentBuilder.toString()) + "content=" + content + ")";
+        return String.format("DOCUMENT(id=%d, version=%d, contentBuilder=%s, ", id, version, contentBuilder.toString()) + "content=" + content + ")";
     }
 }

--- a/src/main/java/com/gdg/backend/domain/document/entity/Document.java
+++ b/src/main/java/com/gdg/backend/domain/document/entity/Document.java
@@ -39,8 +39,10 @@ public class Document extends BaseTimeEntity {
 
     // DB에서 로드 시 content -> contentBuilder 초기화
     @PostLoad
+    @PostPersist
     public void initContentBuilder() {
         this.contentBuilder = new StringBuilder(content != null ? content : "");
+        System.out.println("DOCUMENT " + id + " CONTENTBUILDER INITIATED (value=" + contentBuilder + ")");
     }
 
     // INSERT, UPDATE 전 contentBuilder -> content 동기화
@@ -56,6 +58,6 @@ public class Document extends BaseTimeEntity {
 
     @Override
     public String toString() {
-        return String.format("DOCUMENT(id=%d, version=%d, ", id, version) + "content=" + content + ")";
+        return String.format("DOCUMENT(id=%d, version=%d, contentBuilder=%s", id, version, contentBuilder.toString()) + "content=" + content + ")";
     }
 }

--- a/src/main/java/com/gdg/backend/domain/operation/controller/WebsocketEventController.java
+++ b/src/main/java/com/gdg/backend/domain/operation/controller/WebsocketEventController.java
@@ -1,12 +1,12 @@
 package com.gdg.backend.domain.operation.controller;
 
+import com.gdg.backend.domain.helprequest.dto.HelpRequestDto;
 import com.gdg.backend.domain.operation.dto.OperationRequestDto;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.CrossOrigin;
 
 import java.util.concurrent.BlockingQueue;
 
@@ -26,11 +26,14 @@ public class WebsocketEventController {
 
     /** 클라이언트의 문서 편집 요청을 메시지 큐에 push */
     @MessageMapping("/edit")
-    public void receiveEditOperation(@Valid OperationRequestDto operation) throws InterruptedException {
+    public void handleEditOperation(@Valid OperationRequestDto operation) throws InterruptedException {
         operationQueue.put(operation);
         log.info(operation + " put to queue");
         template.convertAndSend("/sub/ack/" + operation.getDocumentId(), "ACK");
     }
 
-
+    @MessageMapping("/help/{documentId}")
+    public void handleHelpRequest(@Valid HelpRequestDto request) {
+        template.convertAndSend("/sub/ack");
+    }
 }

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -174,6 +174,7 @@ public class OperationQueueProcessor {
                     case INSERT -> doc.getContentBuilder().insert(idx, operation.getInsertContent());
                     case DELETE -> doc.getContentBuilder().delete(idx - operation.getDeleteLength() + 1, idx + 1);
                 }
+                doc.setVersion(documentVersions.get(operation.getDocumentId()).get());
             }
             log.info("current content: {}", doc.getContentBuilder().toString());
             dirtyDocuments.add(docId);
@@ -205,23 +206,25 @@ public class OperationQueueProcessor {
 
     /** 주기적으로 변경된 문서 저장 <br>
      * - DB 쓰기는 네트워크 요청 + 디스크 I/O를 포함하므로 무거움
-     * - processOperation에서 제거해서 실행시간 줄여서 사용자 경험 증가 & 트랜잭션 부하 감소
+     * - DB 작업은 processOperation에서 최대한 제거해서 실행시간 줄여서 지연시간 & 트랜잭션 부하 감소
      * - 실시간성은 documentCache로 유지하고 저장은 백그라운드에서 주기적으로 진행
      * */
     @Scheduled(fixedRate = 10000) // 10초마다 실행
+    public void scheduleSavingDirtyDocuments() {
+        if(!dirtyDocuments.isEmpty()) {
+            log.info("SAVING DIRTY DOCUMENTS (id=" + dirtyDocuments + ")");
+            saveDirtyDocuments();
+        }
+    }
+
     @Transactional
     public void saveDirtyDocuments() {
-        // 로그 출력
-        if(!dirtyDocuments.isEmpty()) log.info("SAVING DIRTY DOCUMENTS (id=" + dirtyDocuments + ")");
         for (Long docId : dirtyDocuments) {
-            Document doc = documentCache.get(docId);
-            if (doc != null) {
-                synchronized (doc) {
-                    log.info("- SAVING DOCUMENT: {}", doc);
-                    doc.syncContentBuilder();
-                    log.info("- AFTER SYNC: {}", doc);
-                    documentRepository.save(doc);
-                    log.info("- AFTER SAVE: {}", doc);
+            Document cachedDoc = documentCache.get(docId);
+            if (cachedDoc != null) {
+                synchronized (cachedDoc) {
+                    cachedDoc.syncContentBuilder();
+                    documentRepository.save(cachedDoc);
                 }
             }
         }

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -169,9 +169,11 @@ public class OperationQueueProcessor {
 
             // 문서 상태 갱신
             int idx = Math.toIntExact(opPosition);
-            switch(operation.getOperation()) {
-                case INSERT -> doc.getContentBuilder().insert(idx, operation.getInsertContent());
-                case DELETE -> doc.getContentBuilder().delete(idx - operation.getDeleteLength() + 1, idx + 1);
+            synchronized (doc) {
+                switch (operation.getOperation()) {
+                    case INSERT -> doc.getContentBuilder().insert(idx, operation.getInsertContent());
+                    case DELETE -> doc.getContentBuilder().delete(idx - operation.getDeleteLength() + 1, idx + 1);
+                }
             }
             log.info("current content: {}", doc.getContentBuilder().toString());
             dirtyDocuments.add(docId);
@@ -215,9 +217,11 @@ public class OperationQueueProcessor {
             Document doc = documentCache.get(docId);
             if (doc != null) {
                 synchronized (doc) {
-                    doc.syncContentBuilder();
                     log.info("- SAVING DOCUMENT: {}", doc);
+                    doc.syncContentBuilder();
+                    log.info("- AFTER SYNC: {}", doc);
                     documentRepository.save(doc);
+                    log.info("- AFTER SAVE: {}", doc);
                 }
             }
         }


### PR DESCRIPTION
<!-- PR 제목은 핵심 변경 사항을 요약해주세요 -->
<!-- ex) feat: 캐스트 생성 기능 추가 -->

## #️⃣ 연관 이슈
<!-- 연관된 이슈 번호를 적어주세요-->
> Closes #37 

## 📝 요약
<!-- 작업 내용을 요약해주세요. -->
- contentBuilder에 작업한 내용이 DB에 저장 안되던 버그 해결


## 변경사항 상세
<!-- 변경되거나 새로 만든 부분에 대한 설명 -->
### Document에서 `syncContentBeforeSave()` 삭제
- detached 상태였던 document를 merge할 때 select문이 호출되면서 `initContentBuilder`를 호출
- content = ""이므로 contentBuilder도 빈 문자열이 됨
- 저장 직전에 `syncContentBeforeSave()`가 호출되면서 빈 문자열인 contentBuilder가 content에 덮어씌워지면서 DB 저장이 안됐음

