### PR TITLE
[UPDATE] Operation 충돌 처리 방식 업데이트

### DIFF
--- a/src/main/java/com/gdg/backend/domain/operation/controller/WebsocketEventController.java
+++ b/src/main/java/com/gdg/backend/domain/operation/controller/WebsocketEventController.java
@@ -27,7 +27,7 @@ public class WebsocketEventController {
     @MessageMapping("/edit")
     public void handleEditOperation(@Valid OperationRequestDto operation) throws InterruptedException {
         operationQueue.put(operation);
-        log.info(operation + " put to queue");
+        log.info("[ENQUEUE] {}", operation);
         template.convertAndSend("/sub/ack/" + operation.getDocumentId(), "ACK");
     }
 }

--- a/src/main/java/com/gdg/backend/domain/operation/entity/Operation.java
+++ b/src/main/java/com/gdg/backend/domain/operation/entity/Operation.java
@@ -26,11 +26,11 @@ public class Operation extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private OperationType operation;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "document_id")
     private Document document;
 

--- a/src/main/java/com/gdg/backend/domain/operation/repository/OperationRepository.java
+++ b/src/main/java/com/gdg/backend/domain/operation/repository/OperationRepository.java
@@ -2,6 +2,8 @@ package com.gdg.backend.domain.operation.repository;
 
 import com.gdg.backend.domain.operation.entity.Operation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,7 +11,8 @@ import java.util.List;
 @Repository
 public interface OperationRepository extends JpaRepository<Operation, Long> {
 
-    List<Operation> findByDocumentIdAndVersionGreaterThan(Long documentId, Long version);
+    @Query("SELECT o FROM Operation o JOIN FETCH o.member JOIN FETCH o.document WHERE o.document.id = :documentId AND o.version > :baseVersion")
+    List<Operation> findByDocumentIdAndVersionGreaterThanFetchJoin(@Param("documentId") Long documentId, @Param("baseVersion") Long version);
 
     void deleteByDocumentId(Long testDocId);
 }

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -21,9 +21,6 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -158,7 +155,7 @@ public class OperationQueueProcessor {
         try {
             // 로그 출력
             log.info("[OPERATION]: {}", operation);
-            List<Operation> concurrentOperations = operationRepository.findByDocumentIdAndVersionGreaterThan(docId, baseVersion);
+            List<Operation> concurrentOperations = operationRepository.findByDocumentIdAndVersionGreaterThanFetchJoin(docId, baseVersion);
             for (Operation concurrentOp : concurrentOperations) {
                 // 본인의 Operation인 경우 충돌 처리 X
                 if (Objects.equals(concurrentOp.getMember().getId(), operation.getUserId()))

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -155,7 +155,6 @@ public class OperationQueueProcessor {
         try {
             // 로그 출력
             log.info("[OPERATION]: {}", operation);
-            boolean doDelete = true;
             List<Operation> concurrentOperations = operationRepository.findByDocumentIdAndVersionGreaterThanFetchJoin(docId, baseVersion);
             for (Operation concurrentOp : concurrentOperations) {
                 // 본인의 Operation인 경우 충돌 처리 X
@@ -173,8 +172,7 @@ public class OperationQueueProcessor {
                     long[] deleteRange = new long[]{concurrentOp.getPosition() - concurrentOp.getDeleteLength() + 1, concurrentOp.getPosition()};
                     if(operation.getOperation().equals(OperationType.DELETE)
                     && deleteRange[0] <= opPosition && opPosition <= deleteRange[1]) {
-                        doDelete = false;
-                        break;
+                        return;
                     }
                     // 현재 operation보다 앞을 삭제한 경우 pos 감소 (등호 미포함)
                     if(concurrentOp.getPosition() < opPosition) opPosition -= concurrentOp.getDeleteLength();
@@ -191,9 +189,7 @@ public class OperationQueueProcessor {
             synchronized (doc) {
                 switch (operation.getOperation()) {
                     case INSERT -> doc.getContentBuilder().insert(idx, operation.getInsertContent());
-                    case DELETE -> {
-                        if(doDelete) doc.getContentBuilder().delete(idx - operation.getDeleteLength() + 1, idx + 1);
-                    }
+                    case DELETE -> doc.getContentBuilder().delete(idx - operation.getDeleteLength() + 1, idx + 1);
                 }
                 doc.setVersion(documentVersions.get(operation.getDocumentId()).get());
             }

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -170,7 +170,9 @@ public class OperationQueueProcessor {
                 else if (concurrentOp.getOperation().equals(OperationType.DELETE)) {
                     if(concurrentOp.getDeleteLength() == null) continue;
                     // 이미 삭제한 문자를 삭제하려는 경우 작업 진행 X
-                    if(operation.getOperation().equals(OperationType.DELETE) && concurrentOp.getPosition().equals(opPosition)) {
+                    long[] deleteRange = new long[]{concurrentOp.getPosition() - concurrentOp.getDeleteLength() + 1, concurrentOp.getPosition()};
+                    if(operation.getOperation().equals(OperationType.DELETE)
+                    && deleteRange[0] <= opPosition && opPosition <= deleteRange[1]) {
                         doDelete = false;
                         break;
                     }

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -155,19 +155,27 @@ public class OperationQueueProcessor {
         try {
             // 로그 출력
             log.info("[OPERATION]: {}", operation);
+            boolean doDelete = true;
             List<Operation> concurrentOperations = operationRepository.findByDocumentIdAndVersionGreaterThanFetchJoin(docId, baseVersion);
             for (Operation concurrentOp : concurrentOperations) {
                 // 본인의 Operation인 경우 충돌 처리 X
-                if (Objects.equals(concurrentOp.getMember().getId(), operation.getUserId()))
+                if(Objects.equals(concurrentOp.getMember().getId(), operation.getUserId()))
                     continue;
-                if (concurrentOp.getOperation().equals(OperationType.INSERT) && concurrentOp.getPosition() < opPosition) {
-                    // 현재 operation보다 앞에 삽입한 경우
+                if(concurrentOp.getPosition() == null) continue;
+                if(concurrentOp.getOperation().equals(OperationType.INSERT) && concurrentOp.getPosition() <= opPosition) {
+                    // 현재 operation보다 앞에 삽입한 경우 pos 증가 (등호 포함)
                     if(concurrentOp.getInsertContent() == null) continue;
                     opPosition += concurrentOp.getInsertContent().length();
-                } else if (concurrentOp.getOperation().equals(OperationType.DELETE) && concurrentOp.getPosition() < opPosition) {
-                    // 현재 operation보다 앞을 삭제한 경우
+                }
+                else if (concurrentOp.getOperation().equals(OperationType.DELETE)) {
                     if(concurrentOp.getDeleteLength() == null) continue;
-                    opPosition -= concurrentOp.getDeleteLength();
+                    // 이미 삭제한 문자를 삭제하려는 경우 작업 진행 X
+                    if(operation.getOperation().equals(OperationType.DELETE) && concurrentOp.getPosition().equals(opPosition)) {
+                        doDelete = false;
+                        break;
+                    }
+                    // 현재 operation보다 앞을 삭제한 경우 pos 감소 (등호 미포함)
+                    if(concurrentOp.getPosition() < opPosition) opPosition -= concurrentOp.getDeleteLength();
                 }
             }
 
@@ -181,7 +189,9 @@ public class OperationQueueProcessor {
             synchronized (doc) {
                 switch (operation.getOperation()) {
                     case INSERT -> doc.getContentBuilder().insert(idx, operation.getInsertContent());
-                    case DELETE -> doc.getContentBuilder().delete(idx - operation.getDeleteLength() + 1, idx + 1);
+                    case DELETE -> {
+                        if(doDelete) doc.getContentBuilder().delete(idx - operation.getDeleteLength() + 1, idx + 1);
+                    }
                 }
                 doc.setVersion(documentVersions.get(operation.getDocumentId()).get());
             }

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -6,6 +6,8 @@ import com.gdg.backend.common.annotation.TrackExecutionTime;
 import com.gdg.backend.domain.document.entity.Document;
 import com.gdg.backend.domain.document.repository.DocumentRepository;
 import com.gdg.backend.domain.enums.OperationType;
+import com.gdg.backend.domain.member.entity.Member;
+import com.gdg.backend.domain.member.repository.MemberRepository;
 import com.gdg.backend.domain.operation.dto.OperationRequestDto;
 import com.gdg.backend.domain.operation.dto.OperationResponseDto;
 import com.gdg.backend.domain.operation.dto.SyncOperationResponseDto;
@@ -39,6 +41,7 @@ public class OperationQueueProcessor {
 
     private final DocumentRepository documentRepository;
     private final OperationRepository operationRepository;
+    private final MemberRepository memberRepository;
     private final BlockingQueue<OperationRequestDto> operationQueue;
     private final SimpMessagingTemplate template;
     private final ConcurrentHashMap<Long, AtomicLong> documentVersions = new ConcurrentHashMap<>();
@@ -198,6 +201,11 @@ public class OperationQueueProcessor {
             // - 동기 처리 vs 비동기 처리
             // - todo 메모리에 Operation 캐싱하기
             //   - Operation 큐 만들어서 캐싱하기 (클라이언트 ACK에 맞춰 갱신)
+            Member author = memberRepository.findById(operation.getUserId())
+                            .orElseGet(() -> {
+                               log.info("- WARNING: member id {} doesn't exist", operation.getUserId());
+                               return null;
+                            });
             operationRepository.save(Operation.builder()
                     .operation(response.getOperation())
                     .document(doc)
@@ -205,7 +213,7 @@ public class OperationQueueProcessor {
                     .insertContent(response.getInsertContent())
                     .deleteLength(response.getDeleteLength())
                     .version(response.getVersion())
-                    .member(null) // todo
+                    .member(author) // todo
                     .build()
             );
 

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -24,6 +24,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
@@ -130,7 +131,7 @@ public class OperationQueueProcessor {
         // - version을 높이지 않음
         // - 추후 전략 패턴 등으로 추상화
         if(operation.getOperation().equals(OperationType.SYNC)) {
-            log.info("Received: SYNC");
+            log.info("[OPERATION] SYNC");
             String docContent = doc.getContentBuilder().toString();
             SyncOperationResponseDto response = new SyncOperationResponseDto(OperationType.SYNC, operation.getUserId(), documentVersions.get(docId).get(), docContent);
             template.convertAndSend("/sub/edit/" + docId, response);
@@ -153,16 +154,19 @@ public class OperationQueueProcessor {
         //   -> 클라이언트 ACK 추적 기능 구현 되면 (2)번으로 갈아타기
         try {
             // 로그 출력
-            log.info("Received: {}", operation);
+            log.info("[OPERATION]: {}", operation);
             List<Operation> concurrentOperations = operationRepository.findByDocumentIdAndVersionGreaterThan(docId, baseVersion);
             for (Operation concurrentOp : concurrentOperations) {
+                // 본인의 Operation인 경우 충돌 처리 X
+                if (Objects.equals(concurrentOp.getMember().getId(), operation.getUserId()))
+                    continue;
                 if (concurrentOp.getOperation().equals(OperationType.INSERT) && concurrentOp.getPosition() < opPosition) {
                     // 현재 operation보다 앞에 삽입한 경우
-                    if(concurrentOp.getInsertContent() == null) continue;;
+                    if(concurrentOp.getInsertContent() == null) continue;
                     opPosition += concurrentOp.getInsertContent().length();
                 } else if (concurrentOp.getOperation().equals(OperationType.DELETE) && concurrentOp.getPosition() < opPosition) {
                     // 현재 operation보다 앞을 삭제한 경우
-                    if(concurrentOp.getDeleteLength() == null) continue;;
+                    if(concurrentOp.getDeleteLength() == null) continue;
                     opPosition -= concurrentOp.getDeleteLength();
                 }
             }
@@ -181,8 +185,14 @@ public class OperationQueueProcessor {
                 }
                 doc.setVersion(documentVersions.get(operation.getDocumentId()).get());
             }
-            log.info("current content: {}", doc.getContentBuilder().toString());
             dirtyDocuments.add(docId);
+
+            // 로그 출력
+            if(!Objects.equals(operation.getPosition(), response.getPosition())) {
+                log.info("- OPERATION TRANSFORMED: pos={}->{}", operation.getPosition(), response.getPosition());
+            }
+            log.info("- saving operation: {}", response);
+            log.info("- current content: {}", doc.getContentBuilder().toString());
 
             // Operation DB에 저장 && Document version 업데이트
             // - 동기 처리 vs 비동기 처리
@@ -198,9 +208,6 @@ public class OperationQueueProcessor {
                     .member(null) // todo
                     .build()
             );
-
-            // 로그 출력
-           log.info("  수정된 Operation: {}", response);
 
             // 클라이언트에 브로드캐스트
             template.convertAndSend("/sub/edit/" + docId, response);

--- a/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
+++ b/src/main/java/com/gdg/backend/domain/operation/service/OperationQueueProcessor.java
@@ -149,12 +149,28 @@ public class OperationQueueProcessor {
                     if(concurrentOp.getDeleteLength() == null) continue;
                     // 이미 삭제한 문자를 삭제하려는 경우 작업 진행 X
                     long[] deleteRange = new long[]{concurrentOp.getPosition() - concurrentOp.getDeleteLength() + 1, concurrentOp.getPosition()};
-                    if(operation.getOperation().equals(OperationType.DELETE)
-                    && deleteRange[0] <= opPosition && opPosition <= deleteRange[1]) {
+                    long[] currentDeleteRange = new long[]{opPosition - operation.getDeleteLength() + 1, opPosition};
+                    // 범위가 완전히 겹치는 경우 Operation을 Drop한다. (DB 저장이나 버전 업데이트도 진행하지 않음)
+                    if (operation.getOperation().equals(OperationType.DELETE) && 
+                            deleteRange[0] <= currentDeleteRange[0] && currentDeleteRange[1] <= deleteRange[1]) {
+                        log.info("- DROP OPERATION (index {} already deleted", opPosition);
                         return;
                     }
-                    // 현재 operation보다 앞을 삭제한 경우 pos 감소 (등호 미포함)
-                    if(concurrentOp.getPosition() < opPosition) opPosition -= concurrentOp.getDeleteLength();
+                    // 범위가 부분적으로 겹치고 현재 Operation이 더 앞 쪽인 경우, pos와 deleteLength를 감소시킨다.
+                    else if (operation.getOperation().equals(OperationType.DELETE) &&
+                            currentDeleteRange[0] < deleteRange[0] && currentDeleteRange[1] <= deleteRange[1]) {
+                        long delta = currentDeleteRange[1] - deleteRange[0];
+                        opPosition -= delta;
+                        operation.setDeleteLength((int) (operation.getDeleteLength() - delta));
+                    }
+                    // 범위가 부분적으로 겹치고 현재 Operation이 더 뒤 쪽인 경우, deleteLength만을 감소시킨다.
+                    else if (operation.getOperation().equals(OperationType.DELETE) &&
+                            deleteRange[0] <= currentDeleteRange[0] && deleteRange[1] < currentDeleteRange[1]) {
+                        long delta = deleteRange[1] - currentDeleteRange[0];
+                        operation.setDeleteLength((int) (operation.getDeleteLength() - delta));
+                    }
+                    // 범위가 겹치지 않고 현재 operation보다 앞을 삭제한 경우 pos 감소 (등호 미포함)
+                    else if(concurrentOp.getPosition() < opPosition) opPosition -= concurrentOp.getDeleteLength();
                 }
             }
 


### PR DESCRIPTION
<!-- PR 제목은 핵심 변경 사항을 요약해주세요 -->
<!-- ex) feat: 캐스트 생성 기능 추가 -->

## #️⃣ 연관 이슈
<!-- 연관된 이슈 번호를 적어주세요-->
> Closes #48 , #49 

## 📝 요약
<!-- 작업 내용을 요약해주세요. -->
- 본인의 Operation끼리는 충돌 처리하지 않도록 변경
- 충돌 처리 로직 세분화함
  - `INSERT` 후 `INSERT` 혹은 `INSERT` 후 `DELETE`
  - `DELETE` 후 `INSERT`
  - `DELETE` 후 `DELETE`
    - 둘 다 범위 삭제인 경우, 범위가 완전히 포함되는지 / 부분적으로 겹치는지 / 아예 안 겹치는지

## 변경사항 상세
<!-- 변경되거나 새로 만든 부분에 대한 설명 -->
### 본인의 Operation끼리는 충돌처리하지 않도록 변경
- #48 
- 본인의 작업인 경우 굳이 충돌이 났다고 가정할 이유가 없음
- Operation 저장 전에 매번 MemberRepository에서 Member 엔티티를 가져오는데, 이왕이면 DB 안들르고 메모리에서 캐싱했으면 함.. 나중에 바꿀듯
- `concurrentOperation`에 접근하면서 `Member`의 id까지 확인하기 때문에 N+1 방지하려고 Member까지 fetch join해서 가져옴
### 충돌 처리 로직 세분화함
- #49 
- OperationA와 OperationB가 겹칠 때 _(= A가 B보단 먼저 처리됐으나, 둘 다 baseVersion이 동일)_, **A와 B의 position이 동일하면 어떻게 되는지** 생각해봤는데 지금 방식으론 부족하다고 느낌
  - `INSERT` 후 `INSERT` 혹은 `INSERT` 후 `DELETE` => 뒤쪽 Operation position 증가해야 함
  - `DELETE` 후 `INSERT` => 뒤쪽 Operation position 그대로여야 함
  - `DELETE` 후 `DELETE`
    - **이미 지워진 인덱스인 경우 지우면 안됨** + **범위 삭제 가능**한 점도 고려
    - 첫 DELETE의 범위가 두 번째 DELETE의 범위를 포함 
    => 처리하지 않고 DROP해야 함 (이미 지워졌으므로)
    - 첫 DELETE의 범위가 두 번째 DELETE의 범위보다 앞서지만 부분적으로 겹침 
    => 두 번째 DELETE의 deleteLength 감소시켜야 함
    - 첫 DELETE의 범위가 두 번째 DELETE의 범위보다 뒤쪽이지만 부분적으로 겹침 
    => 두 번째 DELETE의 position과 deleteLength 감소시켜야 함
    - 첫 DELETE의 범위가 두 번째 DELETE의 범위보다 앞서고, 겹치지 않음
    => 두 번째 DELETE의 position 감소시켜야 함
  - 엄청난 분기문의 탄생
    - 함수로 분리하거나 해야 할 듯,,